### PR TITLE
fix(types): fix types for `Shard#requestGuildMembers`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1061,16 +1061,6 @@ declare namespace Eris {
     id: string;
     username: string;
   }
-  interface RequestGuildMembersOptions extends Omit<FetchMembersOptions, "userIDs"> {
-    nonce: string;
-    user_ids?: string[];
-  }
-  interface RequestGuildMembersReturn {
-    members: Member[];
-    received: number;
-    res: (value?: unknown) => void;
-    timeout: NodeJS.Timer;
-  }
 
   // Message
   interface ActionRow {
@@ -3329,7 +3319,7 @@ declare namespace Eris {
     once<K extends keyof ShardEvents>(event: K, listener: (...args: ShardEvents[K]) => void): this;
     once(event: string, listener: (...args: any[]) => void): this;
     onPacket(packet: RawPacket): void;
-    requestGuildMembers(guildID: string, options?: RequestGuildMembersOptions): Promise<RequestGuildMembersReturn>;
+    requestGuildMembers(guildID: string, options?: FetchMembersOptions): Promise<Member[]>;
     requestGuildSync(guildID: string): void;
     reset(): void;
     restartGuildCreateTimeout(): void;


### PR DESCRIPTION
This PR corrects the typings for `Shard#requestGuildMembers`.

This comes from the fact that `Shard#requestGuildMembers` is being called by `Guild#fetchMembers` with the options and the return value being passed through as-is:  

https://github.com/DonovanDMC/eris/blob/65b1850a22adad774df4150a43a3b60c1a72f2f6/lib/structures/Guild.js#L812-L824

The `guildID` parameter is being kept as a singular string (although there are arrays of strings being passed internally sometimes), as fetching members for multiple guilds at once is not available anymore in newer API versions.